### PR TITLE
[SPIKE] Subscriber table

### DIFF
--- a/Contracts/Commands/OtherCommand.cs
+++ b/Contracts/Commands/OtherCommand.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NServiceBus;
+
+namespace Contracts.Commands
+{
+    public class OtherCommand : ICommand
+    {
+        public Guid CommandId { get; set; }
+    }
+}

--- a/Contracts/Contracts.csproj
+++ b/Contracts/Contracts.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Commands\DemoCommand.cs" />
+    <Compile Include="Commands\OtherCommand.cs" />
     <Compile Include="Events\DemoCommandReceived.cs" />
     <Compile Include="Events\DemoEvent.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/EndpointA/Program.cs
+++ b/EndpointA/Program.cs
@@ -27,7 +27,7 @@ namespace EndpointA
             endpointConfiguration.SendFailedMessagesTo("error");
 
             var routingConfig = endpointConfiguration.UseTransport<MsmqTransport>().Routing();
-            routingConfig.RegisterPublisher(typeof(DemoCommandReceived), "endpointB");
+            routingConfig.RegisterPublisher(typeof(DemoCommandReceived), "endpointC");
             routingConfig.InstanceMappingFile().FilePath("instance-mapping.xml");
 
             endpointConfiguration.EnableFeature<FileBasedRoutingFeature>();
@@ -48,8 +48,9 @@ namespace EndpointA
                 {
                     var commandId = Guid.NewGuid();
                     await endpoint.Send(new DemoCommand { CommandId = commandId });
+                    await endpoint.Send(new OtherCommand { CommandId = commandId });
                     Console.WriteLine();
-                    Console.WriteLine("Sent command with id: " + commandId);
+                    Console.WriteLine("Sent commands with id: " + commandId);
                 }
 
                 if (key.Key == ConsoleKey.E)

--- a/EndpointA/endpoints.xml
+++ b/EndpointA/endpoints.xml
@@ -3,6 +3,17 @@
   <endpoint name="endpointB">
     <handles>
       <command type="Contracts.Commands.DemoCommand, Contracts" />
+      <event type="Contracts.Events.DemoEvent, Contracts" />
+    </handles>
+  </endpoint>
+  <endpoint name="endpointA">
+    <handles>
+      <event type="Contracts.Events.DemoCommandReceived, Contracts" />
+    </handles>
+  </endpoint>
+  <endpoint name="endpointC">
+    <handles>
+      <command type="Contracts.Commands.OtherCommand, Contracts" />
     </handles>
   </endpoint>
 </endpoints>

--- a/EndpointB_1/EndpointB_1.csproj
+++ b/EndpointB_1/EndpointB_1.csproj
@@ -64,6 +64,12 @@
       <Name>NServiceBus.FileBasedRouting</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\EndpointA\endpoints.xml">
+      <Link>endpoints.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="..\EndpointB\EndpointB.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/EndpointC/App.config
+++ b/EndpointC/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    </startup>
+</configuration>

--- a/EndpointC/DemoCommandHandler.cs
+++ b/EndpointC/DemoCommandHandler.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using Contracts.Commands;
+using Contracts.Events;
+using NServiceBus;
+
+namespace EndpointC
+{
+    class OtherCommandHandler : IHandleMessages<OtherCommand>
+    {
+        public Task Handle(OtherCommand message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Received {nameof(OtherCommand)} {message.CommandId}");
+            return context.Publish(new DemoCommandReceived { ReceivedCommandId = message.CommandId });
+        }
+    }
+}

--- a/EndpointC/DemoEventHandler.cs
+++ b/EndpointC/DemoEventHandler.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using Contracts.Events;
+using NServiceBus;
+
+namespace EndpointC
+{
+    class DemoEventHandler : IHandleMessages<DemoEvent>
+    {
+        public Task Handle(DemoEvent message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Received {nameof(DemoEvent)} {message.EventId}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/EndpointC/EndpointC.csproj
+++ b/EndpointC/EndpointC.csproj
@@ -4,14 +4,15 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{9B21E30F-61C0-4404-BB18-88CEBC69122C}</ProjectGuid>
+    <ProjectGuid>{A1595C02-E64F-4DAF-A535-A043E4EB641A}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>EndpointB_2</RootNamespace>
-    <AssemblyName>EndpointB_2</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <RootNamespace>EndpointC</RootNamespace>
+    <AssemblyName>EndpointC</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,6 +48,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DemoCommandHandler.cs" />
+    <Compile Include="DemoEventHandler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -59,18 +62,7 @@
       <Project>{fb64c215-540a-4ed1-901f-1e0a242d0908}</Project>
       <Name>Contracts</Name>
     </ProjectReference>
-    <ProjectReference Include="..\NServiceBus.FileBasedRouting\NServiceBus.FileBasedRouting.csproj">
-      <Project>{b6417ca5-3892-4c53-8356-31018692ae35}</Project>
-      <Name>NServiceBus.FileBasedRouting</Name>
-    </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\EndpointA\endpoints.xml">
-      <Link>endpoints.xml</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <Import Project="..\EndpointB\EndpointB.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/EndpointC/Program.cs
+++ b/EndpointC/Program.cs
@@ -1,29 +1,27 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Contracts.Events;
 using NServiceBus;
-using NServiceBus.Features;
-using NServiceBus.FileBasedRouting;
-using NServiceBus.Persistence;
 
-namespace EndpointB
+namespace EndpointC
 {
-    static class Configuration
+    class Program
     {
-        public static async Task Start(string discriminator)
+        static void Main(string[] args)
         {
-            var endpointConfiguration = new EndpointConfiguration("endpointB");
-            endpointConfiguration.MakeInstanceUniquelyAddressable(discriminator);
+            Start().GetAwaiter().GetResult();
+        }
+
+        static async Task Start()
+        {
+            var endpointConfiguration = new EndpointConfiguration("endpointC");
 
             endpointConfiguration.UsePersistence<InMemoryPersistence>();
             endpointConfiguration.SendFailedMessagesTo("error");
+            endpointConfiguration.EnableInstallers();
 
             var routingConfig = endpointConfiguration.UseTransport<MsmqTransport>().Routing();
             routingConfig.RegisterPublisher(typeof(DemoEvent), "endpointA");
-
-            endpointConfiguration.EnableFeature<FileBasedRoutingFeature>();
 
             var endpoint = await Endpoint.Start(endpointConfiguration);
 

--- a/EndpointC/Properties/AssemblyInfo.cs
+++ b/EndpointC/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EndpointC")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EndpointC")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a1595c02-e64f-4daf-a535-a043e4eb641a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/EndpointC/packages.config
+++ b/EndpointC/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NServiceBus" version="6.0.0" targetFramework="net452" />
+</packages>

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/Commands/A.cs
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/Commands/A.cs
@@ -1,6 +1,0 @@
-﻿namespace NServiceBus.FileBasedRouting.Tests.Contracts.Commands
-{
-    public class A
-    {
-    }
-}

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/Commands/B.cs
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/Commands/B.cs
@@ -1,6 +1,0 @@
-﻿namespace NServiceBus.FileBasedRouting.Tests.Contracts.Commands
-{
-    public class B
-    {
-    }
-}

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/NServiceBus.FileBasedRouting.Tests.Contracts.csproj
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/NServiceBus.FileBasedRouting.Tests.Contracts.csproj
@@ -41,8 +41,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="C.cs" />
-    <Compile Include="Commands\A.cs" />
-    <Compile Include="Commands\B.cs" />
+    <Compile Include="Namespace\A.cs" />
+    <Compile Include="Namespace\B.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/Namespace/A.cs
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/Namespace/A.cs
@@ -1,0 +1,6 @@
+﻿namespace NServiceBus.FileBasedRouting.Tests.Contracts.Namespace
+{
+    public class A
+    {
+    }
+}

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/Namespace/B.cs
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/Namespace/B.cs
@@ -1,0 +1,6 @@
+﻿namespace NServiceBus.FileBasedRouting.Tests.Contracts.Namespace
+{
+    public class B
+    {
+    }
+}

--- a/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileTests.cs
+++ b/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Xml.Linq;
 using NServiceBus.FileBasedRouting.Tests.Contracts;
-using NServiceBus.FileBasedRouting.Tests.Contracts.Commands;
+using NServiceBus.FileBasedRouting.Tests.Contracts.Namespace;
 using NUnit.Framework;
 
 namespace NServiceBus.FileBasedRouting.Tests
@@ -15,8 +15,8 @@ namespace NServiceBus.FileBasedRouting.Tests
  <endpoints>
   <endpoint name=""EndpointName"">
     <handles>
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
     </handles>
   </endpoint>
  </endpoints>
@@ -28,6 +28,28 @@ namespace NServiceBus.FileBasedRouting.Tests
             Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
 
             CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Commands);
+        }
+
+        [Test]
+        public void It_can_parse_file_with_single_events()
+        {
+            const string xml = @"
+ <endpoints>
+  <endpoint name=""EndpointName"">
+    <handles>
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+    </handles>
+  </endpoint>
+ </endpoints>
+ ";
+            var configurations = GetConfigurations(xml);
+
+            Assert.AreEqual(1, configurations.Length);
+            var configuration = configurations[0];
+            Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Events);
         }
 
         [Test]
@@ -52,13 +74,34 @@ namespace NServiceBus.FileBasedRouting.Tests
         }
 
         [Test]
+        public void It_can_parse_file_with_events_with_assembly_only()
+        {
+            const string xml = @"
+ <endpoints>
+  <endpoint name=""EndpointName"">
+    <handles>
+      <events assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" />
+    </handles>
+  </endpoint>
+ </endpoints>
+ ";
+            var configurations = GetConfigurations(xml);
+
+            Assert.AreEqual(1, configurations.Length);
+            var configuration = configurations[0];
+            Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B), typeof(C) }, configuration.Events);
+        }
+
+        [Test]
         public void It_can_parse_file_with_commands_with_assembly_and_namespace()
         {
             const string xml = @"
  <endpoints>
   <endpoint name=""EndpointName"">
     <handles>
-      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Commands"" />
+      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
     </handles>
   </endpoint>
  </endpoints>
@@ -73,18 +116,39 @@ namespace NServiceBus.FileBasedRouting.Tests
         }
 
         [Test]
-        public void It_provides_distinct_result_even_when_types_are_registered_multiple_times()
+        public void It_can_parse_file_with_events_with_assembly_and_namespace()
         {
             const string xml = @"
  <endpoints>
   <endpoint name=""EndpointName"">
     <handles>
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
-      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Commands.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
-      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Commands"" />
-      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Commands"" />
+      <events assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
+    </handles>
+  </endpoint>
+ </endpoints>
+ ";
+            var configurations = GetConfigurations(xml);
+
+            Assert.AreEqual(1, configurations.Length);
+            var configuration = configurations[0];
+            Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Events);
+        }
+
+        [Test]
+        public void It_provides_distinct_result_even_when_commands_are_registered_multiple_times()
+        {
+            const string xml = @"
+ <endpoints>
+  <endpoint name=""EndpointName"">
+    <handles>
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <command type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
+      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
     </handles>
   </endpoint>
  </endpoints>
@@ -96,6 +160,32 @@ namespace NServiceBus.FileBasedRouting.Tests
             Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
 
             CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Commands);
+        }
+
+        [Test]
+        public void It_provides_distinct_result_even_when_events_are_registered_multiple_times()
+        {
+            const string xml = @"
+ <endpoints>
+  <endpoint name=""EndpointName"">
+    <handles>
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.A, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <event type = ""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace.B, NServiceBus.FileBasedRouting.Tests.Contracts"" />
+      <events assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
+      <events assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace=""NServiceBus.FileBasedRouting.Tests.Contracts.Namespace"" />
+    </handles>
+  </endpoint>
+ </endpoints>
+ ";
+            var configurations = GetConfigurations(xml);
+
+            Assert.AreEqual(1, configurations.Length);
+            var configuration = configurations[0];
+            Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Events);
         }
 
 

--- a/NServiceBus.FileBasedRouting.sln
+++ b/NServiceBus.FileBasedRouting.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.FileBasedRouting", "NServiceBus.FileBasedRouting\NServiceBus.FileBasedRouting.csproj", "{B6417CA5-3892-4C53-8356-31018692AE35}"
 EndProject
@@ -21,11 +21,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.FileBasedRoutin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.FileBasedRouting.Tests.Contracts", "NServiceBus.FileBasedRouting.Tests.Contracts\NServiceBus.FileBasedRouting.Tests.Contracts.csproj", "{88F2D59F-CE5D-4BD5-B9EB-494A2728AD98}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointC", "EndpointC\EndpointC.csproj", "{A1595C02-E64F-4DAF-A535-A043E4EB641A}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		EndpointB\EndpointB.projitems*{54093e78-eb7c-46e5-b495-3d6198eafa5c}*SharedItemsImports = 13
-		EndpointB\EndpointB.projitems*{9b21e30f-61c0-4404-bb18-88cebc69122c}*SharedItemsImports = 4
 		EndpointB\EndpointB.projitems*{eb4b2281-8c83-4bab-b35b-a30c94b939fe}*SharedItemsImports = 4
+		EndpointB\EndpointB.projitems*{9b21e30f-61c0-4404-bb18-88cebc69122c}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -60,6 +62,10 @@ Global
 		{88F2D59F-CE5D-4BD5-B9EB-494A2728AD98}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88F2D59F-CE5D-4BD5-B9EB-494A2728AD98}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88F2D59F-CE5D-4BD5-B9EB-494A2728AD98}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1595C02-E64F-4DAF-A535-A043E4EB641A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1595C02-E64F-4DAF-A535-A043E4EB641A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1595C02-E64F-4DAF-A535-A043E4EB641A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1595C02-E64F-4DAF-A535-A043E4EB641A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -70,5 +76,6 @@ Global
 		{54093E78-EB7C-46E5-B495-3D6198EAFA5C} = {5C4D228C-9FF6-4F63-B413-68CC922EB652}
 		{EB4B2281-8C83-4BAB-B35B-A30C94B939FE} = {5C4D228C-9FF6-4F63-B413-68CC922EB652}
 		{9B21E30F-61C0-4404-BB18-88CEBC69122C} = {5C4D228C-9FF6-4F63-B413-68CC922EB652}
+		{A1595C02-E64F-4DAF-A535-A043E4EB641A} = {5C4D228C-9FF6-4F63-B413-68CC922EB652}
 	EndGlobalSection
 EndGlobal

--- a/NServiceBus.FileBasedRouting/EndpointRoutingConfiguration.cs
+++ b/NServiceBus.FileBasedRouting/EndpointRoutingConfiguration.cs
@@ -7,5 +7,6 @@ namespace NServiceBus.FileBasedRouting
         public string LogicalEndpointName { get; set; }
 
         public Type[] Commands { get; set; }
+        public Type[] Events { get; set; }
     }
 }

--- a/NServiceBus.FileBasedRouting/FileBasedRoutingFeature.cs
+++ b/NServiceBus.FileBasedRouting/FileBasedRoutingFeature.cs
@@ -29,15 +29,15 @@ namespace NServiceBus.FileBasedRouting
                 document = XDocument.Load(fileStream);
             }
 
-            var routingFile = new XmlRoutingFileParser(document);
+            var routingFileParser = new XmlRoutingFileParser(document);
 
             // ensure the routing file is valid and the routing table is populated before running FeatureStartupTasks
-            UpdateRoutingTable(routingFile, routing.Sending, routing.Publishing);
+            UpdateRoutingTable(routingFileParser, routing.Sending, routing.Publishing);
 
-            context.RegisterStartupTask(new UpdateRoutingTask(routingFile, routing.Sending, routing.Publishing));
+            context.RegisterStartupTask(new UpdateRoutingTask(routingFileParser, routing.Sending, routing.Publishing));
         }
 
-        private static void UpdateRoutingTable(XmlRoutingFile routingFile, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
+        private static void UpdateRoutingTable(XmlRoutingFileParser routingFileParser, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
         {
             var endpoints = routingFileParser.Read();
 
@@ -68,7 +68,7 @@ namespace NServiceBus.FileBasedRouting
             private readonly UnicastSubscriberTable subscriberTable;
             private Timer updateTimer;
 
-            public UpdateRoutingTask(XmlRoutingFile routingFile, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
+            public UpdateRoutingTask(XmlRoutingFileParser routingFileParser, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
             {
                 this.routingFileParser = routingFileParser;
                 this.unicastRoutingTable = unicastRoutingTable;
@@ -77,7 +77,7 @@ namespace NServiceBus.FileBasedRouting
 
             protected override Task OnStart(IMessageSession session)
             {
-                updateTimer = new Timer(state => UpdateRoutingTable(routingFile, unicastRoutingTable, subscriberTable), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+                updateTimer = new Timer(state => UpdateRoutingTable(routingFileParser, unicastRoutingTable, subscriberTable), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
 
                 return Task.CompletedTask;
             }

--- a/NServiceBus.FileBasedRouting/FileBasedRoutingFeature.cs
+++ b/NServiceBus.FileBasedRouting/FileBasedRoutingFeature.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.FileBasedRouting
 
         protected override void Setup(FeatureConfigurationContext context)
         {
-            var unicastRoutingTable = context.Settings.Get<UnicastRoutingTable>();
+            var routing = context.Settings.Get<IRoutingComponent>();
             XDocument document;
             using (var fileStream = File.OpenRead(context.Settings.Get<string>(RoutingFilePathKey)))
             {
@@ -32,16 +32,17 @@ namespace NServiceBus.FileBasedRouting
             var routingFile = new XmlRoutingFileParser(document);
 
             // ensure the routing file is valid and the routing table is populated before running FeatureStartupTasks
-            UpdateRoutingTable(routingFile, unicastRoutingTable);
+            UpdateRoutingTable(routingFile, routing.Sending, routing.Publishing);
 
-            context.RegisterStartupTask(new UpdateRoutingTask(routingFile, unicastRoutingTable));
+            context.RegisterStartupTask(new UpdateRoutingTask(routingFile, routing.Sending, routing.Publishing));
         }
 
-        private static void UpdateRoutingTable(XmlRoutingFileParser routingFileParser, UnicastRoutingTable unicastRoutingTable)
+        private static void UpdateRoutingTable(XmlRoutingFile routingFile, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
         {
             var endpoints = routingFileParser.Read();
 
             var commandRoutes = new List<RouteTableEntry>();
+            var eventRoutes = new List<RouteTableEntry>();
             foreach (var endpoint in endpoints)
             {
                 foreach (var command in endpoint.Commands)
@@ -49,26 +50,34 @@ namespace NServiceBus.FileBasedRouting
                     commandRoutes.Add(new RouteTableEntry(command,
                         UnicastRoute.CreateFromEndpointName(endpoint.LogicalEndpointName)));
                 }
+                foreach (var @event in endpoint.Events)
+                {
+                    eventRoutes.Add(new RouteTableEntry(@event,
+                        UnicastRoute.CreateFromEndpointName(endpoint.LogicalEndpointName)));
+                }
             }
 
             unicastRoutingTable.AddOrReplaceRoutes("FileBasedRouting", commandRoutes);
+            subscriberTable.AddOrReplaceRoutes("FiledBasedRouting", eventRoutes);
         }
 
         class UpdateRoutingTask : FeatureStartupTask, IDisposable
         {
             private readonly XmlRoutingFileParser routingFileParser;
             private readonly UnicastRoutingTable unicastRoutingTable;
+            private readonly UnicastSubscriberTable subscriberTable;
             private Timer updateTimer;
 
-            public UpdateRoutingTask(XmlRoutingFileParser routingFileParser, UnicastRoutingTable unicastRoutingTable)
+            public UpdateRoutingTask(XmlRoutingFile routingFile, UnicastRoutingTable unicastRoutingTable, UnicastSubscriberTable subscriberTable)
             {
                 this.routingFileParser = routingFileParser;
                 this.unicastRoutingTable = unicastRoutingTable;
+                this.subscriberTable = subscriberTable;
             }
 
             protected override Task OnStart(IMessageSession session)
             {
-                updateTimer = new Timer(state => UpdateRoutingTable(routingFileParser, unicastRoutingTable), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+                updateTimer = new Timer(state => UpdateRoutingTable(routingFile, unicastRoutingTable, subscriberTable), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
 
                 return Task.CompletedTask;
             }

--- a/NServiceBus.FileBasedRouting/routing.xsd
+++ b/NServiceBus.FileBasedRouting/routing.xsd
@@ -19,6 +19,17 @@
                         <xs:attribute name="namespace" type="xs:string" use="optional" />
                       </xs:complexType>
                     </xs:element>
+                    <xs:element minOccurs="0" maxOccurs="unbounded" name="event">
+                      <xs:complexType>
+                        <xs:attribute name="type" type="xs:string" use="required" />
+                      </xs:complexType>
+                    </xs:element>
+                    <xs:element minOccurs="0" maxOccurs="unbounded" name="events">
+                      <xs:complexType>
+                        <xs:attribute name="assembly" type="xs:string" use="required" />
+                        <xs:attribute name="namespace" type="xs:string" use="optional" />
+                      </xs:complexType>
+                    </xs:element>
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>


### PR DESCRIPTION
Using subscriber table approach (https://github.com/Particular/NServiceBus/pull/4316) for the centralized event routing.
 * Adds handling of `event` and `events` nodes in the XML
 * Registers the subscriber routes
 * Adds `EndpointC` to the sample in order to show the interop with an endpoint that uses classic MDPS: `EndpointC` can process events published by `A` because `A` understands its subscribe message. Because `A` has a configures subscriber route, it can use MDPS to subscribe to the event published by `C`.