### PR TITLE
Null namespace handling

### DIFF
--- a/NServiceBus.FileBasedRouting.Tests.Contracts/D.cs
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/D.cs
@@ -1,0 +1,5 @@
+﻿ // ReSharper disable once CheckNamespace
+public class D
+{
+
+}

--- a/NServiceBus.FileBasedRouting.Tests.Contracts/NServiceBus.FileBasedRouting.Tests.Contracts.csproj
+++ b/NServiceBus.FileBasedRouting.Tests.Contracts/NServiceBus.FileBasedRouting.Tests.Contracts.csproj
@@ -43,6 +43,7 @@
     <Compile Include="C.cs" />
     <Compile Include="Commands\A.cs" />
     <Compile Include="Commands\B.cs" />
+    <Compile Include="D.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileTests.cs
+++ b/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileTests.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.FileBasedRouting.Tests
             var configuration = configurations[0];
             Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
 
-            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B), typeof(C) }, configuration.Commands);
+            CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B), typeof(C), typeof(D) }, configuration.Commands);
         }
 
         [Test]
@@ -70,6 +70,27 @@ namespace NServiceBus.FileBasedRouting.Tests
             Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
 
             CollectionAssert.AreEquivalent(new[] { typeof(A), typeof(B) }, configuration.Commands);
+        }
+
+        [Test]
+        public void It_can_parse_file_with_commands_with_assembly_and_empty_namespace()
+        {
+            const string xml = @"
+ <endpoints>
+  <endpoint name=""EndpointName"">
+    <handles>
+      <commands assembly = ""NServiceBus.FileBasedRouting.Tests.Contracts"" namespace="""" />
+    </handles>
+  </endpoint>
+ </endpoints>
+ ";
+            var configurations = GetConfigurations(xml);
+
+            Assert.AreEqual(1, configurations.Length);
+            var configuration = configurations[0];
+            Assert.AreEqual("EndpointName", configuration.LogicalEndpointName);
+
+            CollectionAssert.AreEquivalent(new[] { typeof(D) }, configuration.Commands);
         }
 
         [Test]

--- a/NServiceBus.FileBasedRouting/XmlRoutingFileParser.cs
+++ b/NServiceBus.FileBasedRouting/XmlRoutingFileParser.cs
@@ -68,11 +68,16 @@ namespace NServiceBus.FileBasedRouting
             {
                 return exportedTypes;
             }
-            return
-                exportedTypes.Where(
-                    type => type.Namespace != null && type.Namespace.StartsWith(@namespace.Value));
-        }
 
+            // the namespace attribute exists, but it's empty
+            if (string.IsNullOrEmpty(@namespace.Value))
+            {
+                // return only types with no namespace at all
+                return exportedTypes.Where(type => string.IsNullOrEmpty(type.Namespace));
+            }
+
+            return exportedTypes.Where(type => type.Namespace != null && type.Namespace.StartsWith(@namespace.Value));
+        }
 
         readonly XDocument document;
         readonly XmlSchemaSet schema;

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageRestore>
+    <clear />
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="particular myget.org" value="https://www.myget.org/F/particular/" />
+  </packageSources>
+  <disabledPackageSources />
+  <config>
+    <add key="DependencyVersion" value="HighestMinor" />
+  </config>
+  <activePackageSource>
+    <clear />
+    <add key="All" value="(Aggregate source)" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
Empty namespace in the file routing imports only types with no namespace at all.
Solves #7 

This is the best I could come up with. We could move namespace to the element and use empty tag or `nil`, but after considering this change, I came to the conclusion that having types with no namespaces does not happen that often and we can simply use `""` as a discriminator of it.