### PR TITLE
Allow uri configuration for routing file path

### DIFF
--- a/src/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileAccessTests.cs
+++ b/src/NServiceBus.FileBasedRouting.Tests/XmlRoutingFileAccessTests.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Should_throw_when_file_not_found()
         {
-            var fileAccess = new XmlRoutingFileAccess("non-existing.file");
+            var fileAccess = new XmlRoutingFileAccess(new Uri("non-existing.file", UriKind.RelativeOrAbsolute));
 
             Assert.Throws<FileNotFoundException>(() => fileAccess.Read());
         }
@@ -19,7 +19,7 @@
         public void Should_return_loaded_document()
         {
             var fileName = "hello-world.xml";
-            var fileAccess = new XmlRoutingFileAccess(fileName);
+            var fileAccess = new XmlRoutingFileAccess(new Uri(fileName, UriKind.RelativeOrAbsolute));
 
             File.WriteAllText(fileName, "<greeting>Hello World!</greeting>");
             try
@@ -38,7 +38,7 @@
         public void Should_load_valid_xml_content()
         {
             var fileName = "hello-world.html";
-            var fileAccess = new XmlRoutingFileAccess(fileName);
+            var fileAccess = new XmlRoutingFileAccess(new Uri(fileName, UriKind.RelativeOrAbsolute));
 
             File.WriteAllText(fileName, "<h1>Hello World!</h1>");
             try
@@ -57,7 +57,7 @@
         public void Should_throw_when_file_contains_no_xml_content()
         {
             var fileName = "hello-world.txt";
-            var fileAccess = new XmlRoutingFileAccess(fileName);
+            var fileAccess = new XmlRoutingFileAccess(new Uri(fileName, UriKind.RelativeOrAbsolute));
 
             File.WriteAllText(fileName, "Hello World!");
             try

--- a/src/NServiceBus.FileBasedRouting/FileBasedRoutingConfigExtensions.cs
+++ b/src/NServiceBus.FileBasedRouting/FileBasedRoutingConfigExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using NServiceBus.Configuration.AdvanceExtensibility;
+using System;
 
 namespace NServiceBus.FileBasedRouting
 {
@@ -22,7 +23,17 @@ namespace NServiceBus.FileBasedRouting
         /// <param name="configurationFilePath">The path to the configuration file.</param>
         public static void UseFileBasedRouting(this RoutingSettings config, string configurationFilePath)
         {
-            config.GetSettings().Set(FileBasedRoutingFeature.RoutingFilePathKey, configurationFilePath);
+            config.UseFileBasedRouting(UriHelper.FilePathToUri(configurationFilePath));
+        }
+
+        /// <summary>
+        /// Enables routing configured with the routing configuration file under <paramref name="configurationFileUri"/>
+        /// </summary>
+        /// <param name="config">The configuration object.</param>
+        /// <param name="configurationFileUri">The <see cref="Uri"/> to the configuration file.</param>
+        public static void UseFileBasedRouting(this RoutingSettings config, Uri configurationFileUri)
+        {
+            config.GetSettings().Set(FileBasedRoutingFeature.RoutingFilePathKey, configurationFileUri);
             config.GetSettings().EnableFeatureByDefault<FileBasedRoutingFeature>();
         }
     }

--- a/src/NServiceBus.FileBasedRouting/NServiceBus.FileBasedRouting.csproj
+++ b/src/NServiceBus.FileBasedRouting/NServiceBus.FileBasedRouting.csproj
@@ -47,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UriHelper.cs" />
     <Compile Include="XmlRoutingFileAccess.cs" />
     <Compile Include="UnicastRouteGroup.cs" />
     <Compile Include="EndpointRoutingConfiguration.cs" />

--- a/src/NServiceBus.FileBasedRouting/UriHelper.cs
+++ b/src/NServiceBus.FileBasedRouting/UriHelper.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.FileBasedRouting
+{
+    using System;
+    using System.IO;
+
+    class UriHelper
+    {
+        public static Uri FilePathToUri(string filePath)
+        {
+            var absoluteFilePath = Path.IsPathRooted(filePath)
+                ? filePath
+                : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
+            return new Uri(absoluteFilePath, UriKind.Absolute);
+        }
+    }
+}

--- a/src/NServiceBus.FileBasedRouting/XmlRoutingFileAccess.cs
+++ b/src/NServiceBus.FileBasedRouting/XmlRoutingFileAccess.cs
@@ -1,27 +1,23 @@
 ﻿namespace NServiceBus.FileBasedRouting
 {
     using System;
-    using System.IO;
     using System.Xml;
     using System.Xml.Linq;
 
     class XmlRoutingFileAccess
     {
-        public string FilePath { get; }
+        public Uri FileUri { get; }
 
-        public XmlRoutingFileAccess(string filePath)
+        public XmlRoutingFileAccess(Uri fileUri)
         {
-            FilePath = filePath;
+            FileUri = fileUri;
         }
 
         public XDocument Read()
         {
             try
             {
-                using (var fileStream = File.OpenRead(FilePath))
-                {
-                    return XDocument.Load(fileStream);
-                }
+                return XDocument.Load(FileUri.ToString());
             }
             catch (XmlException e)
             {


### PR DESCRIPTION
implements #15 

I did a quick check and turns out `XDocument.Load` can already load files from an uri quite easily. So I added a new parameter to enable FBR to accept an URI which can be used to load the routing file from a webserver or e.g. Azure blob storage (was using this for testing).

ping @SzymonPobiega @Scooletz @janovesk 

I think we should consider adding this capability for the endpoint instance mapping file too. Thoughts @andreasohlund @danielmarbach 